### PR TITLE
Use markdoc for parsing markdown on the server

### DIFF
--- a/app/components/post-list.tsx
+++ b/app/components/post-list.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@remix-run/react";
-import { marked } from "marked";
 
 interface Post {
   slug: string;
@@ -43,11 +42,5 @@ export function PostTitle({
 }) {
   const Element = asElement ?? "span";
 
-  return (
-    <Element
-      dangerouslySetInnerHTML={{
-        __html: marked.parseInline(title),
-      }}
-    />
-  );
+  return <Element>{title}</Element>;
 }

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -6,3 +6,4 @@ export const HOST =
   process.env.NODE_ENV === "production"
     ? "https://tom-sherman.com"
     : "http://localhost:8788";
+export const SHIKI_PATH = "/build/shiki";

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -7,6 +7,11 @@ startTransition(() => {
     document,
     <StrictMode>
       <RemixBrowser />
-    </StrictMode>
+    </StrictMode>,
+    {
+      onRecoverableError() {
+        // Ignore recoverable errors
+      },
+    }
   );
 });

--- a/app/lib/blog-data.server.ts
+++ b/app/lib/blog-data.server.ts
@@ -2,7 +2,6 @@ import type { request as githubRequest } from "@octokit/request";
 import type { SelectType } from "kysely";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
-import { marked } from "marked";
 import { z } from "zod";
 
 const frontMatterTagsSchema = z.array(z.string());
@@ -323,8 +322,4 @@ function parseFrontMatter(input: string) {
     contentStart,
     attributes: frontMatterSchema.parse(frontMatter),
   };
-}
-
-export function renderPostToHtml(content: string) {
-  return marked(content);
 }

--- a/app/lib/markdown/markdown.server.ts
+++ b/app/lib/markdown/markdown.server.ts
@@ -1,0 +1,6 @@
+import { parse, transform } from "@markdoc/markdoc";
+
+export function parseMarkdown(markdown: string) {
+  const ast = parse(markdown);
+  return transform(ast);
+}

--- a/app/lib/markdown/renderer.tsx
+++ b/app/lib/markdown/renderer.tsx
@@ -1,0 +1,55 @@
+import type { RenderableTreeNodes, Scalar, Tag } from "@markdoc/markdoc";
+
+import type { ComponentType, ReactNode } from "react";
+import { createElement, memo } from "react";
+
+function isTag(node: any): node is Tag {
+  return node && node.$$mdtype === "Tag";
+}
+
+type Component = ComponentType<any>;
+
+export default memo(function MarkdownRenderer({
+  components = {},
+  content,
+}: {
+  components?: Record<string, Component>;
+  content: RenderableTreeNodes;
+}) {
+  function deepRender(value: any): any {
+    if (value == null || typeof value !== "object") return value;
+
+    if (Array.isArray(value)) return value.map((item) => deepRender(item));
+
+    if (value.$$mdtype === "Tag") return render(value);
+
+    if (typeof value !== "object") return value;
+
+    const output: Record<string, Scalar> = {};
+    for (const [k, v] of Object.entries(value)) output[k] = deepRender(v);
+    return output;
+  }
+
+  function render(node: RenderableTreeNodes): ReactNode {
+    if (Array.isArray(node)) return <>{node.map(render)}</>;
+
+    if (node === null || typeof node !== "object" || !isTag(node))
+      return node as any;
+
+    const {
+      name,
+      attributes: { class: className, ...attrs } = {},
+      children = [],
+    } = node;
+
+    if (className) attrs.className = className;
+
+    return createElement(
+      components[name] ?? name,
+      Object.keys(attrs).length == 0 ? null : deepRender(attrs),
+      ...children.map(render)
+    );
+  }
+
+  return render(content) as any;
+});

--- a/app/lib/shiki.client.tsx
+++ b/app/lib/shiki.client.tsx
@@ -1,0 +1,82 @@
+import { memo, useEffect, useState, useSyncExternalStore } from "react";
+import type { Highlighter } from "shiki";
+import { getHighlighter, setCDN } from "shiki";
+import { SHIKI_PATH } from "~/constants";
+import { createCache } from "suspense";
+
+export type { Highlighter } from "shiki";
+
+setCDN(`${SHIKI_PATH}/`);
+const highlighterPromise = getHighlighter({
+  langs: [],
+  themes: [],
+});
+
+const highlighterCache = createCache<
+  [language: string, theme: string],
+  Highlighter
+>({
+  load: async (language, theme) => {
+    console.log("Loading highlighter", language, theme);
+    const highlighter = await highlighterPromise;
+    const loadedLanguages = highlighter.getLoadedLanguages();
+    const loadedThemes = highlighter.getLoadedThemes();
+
+    let promises = [];
+    if (!loadedLanguages.includes(language)) {
+      promises.push(highlighter.loadLanguage(language as any));
+    }
+
+    if (!loadedThemes.includes(theme)) {
+      promises.push(highlighter.loadTheme(theme));
+    }
+
+    await Promise.all(promises);
+
+    return highlighter;
+  },
+});
+
+interface HighlightedCodeProps {
+  children: string;
+  language: string;
+}
+
+export const HighlightedCode = memo(function HighlightedCode({
+  children: codeString,
+  language,
+}: HighlightedCodeProps) {
+  const colorMode = useColorMode();
+  const theme = colorMode === "dark" ? "github-dark" : "github-light";
+  const highlighter = highlighterCache.fetchSuspense(language, theme);
+
+  const container = document.createElement("div");
+  container.innerHTML = highlighter.codeToHtml(codeString, {
+    lang: language,
+    theme: theme,
+  });
+
+  const codeElement = container.querySelector("code")!;
+
+  return <code dangerouslySetInnerHTML={{ __html: codeElement.innerHTML }} />;
+});
+
+function useColorMode(inferredServerValue?: "light" | "dark") {
+  return useSyncExternalStore(
+    (callback) => {
+      const listener = () => {
+        callback();
+      };
+      window.addEventListener("color-mode-change", listener);
+      return () => {
+        window.removeEventListener("color-mode-change", listener);
+      };
+    },
+    () => {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    },
+    () => inferredServerValue ?? "light"
+  );
+}

--- a/app/lib/shiki.client.tsx
+++ b/app/lib/shiki.client.tsx
@@ -7,9 +7,11 @@ import { createCache } from "suspense";
 export type { Highlighter } from "shiki";
 
 setCDN(`${SHIKI_PATH}/`);
+
+const darkModePreference = window.matchMedia("(prefers-color-scheme: dark)");
 const highlighterPromise = getHighlighter({
   langs: [],
-  themes: [],
+  themes: [darkModePreference.matches ? "github-dark" : "github-light"],
 });
 
 const highlighterCache = createCache<
@@ -61,7 +63,6 @@ export const HighlightedCode = memo(function HighlightedCode({
   return <code dangerouslySetInnerHTML={{ __html: codeElement.innerHTML }} />;
 });
 
-const darkModePreference = window.matchMedia("(prefers-color-scheme: dark)");
 function useColorMode() {
   return useSyncExternalStore(
     (callback) => {

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -21,6 +21,7 @@ import type { RenderableTreeNode } from "@markdoc/markdoc";
 import { Suspense } from "react";
 import RenderMarkdown from "~/lib/markdown/renderer";
 import { HighlightedCode } from "~/lib/shiki.client";
+import { SHIKI_PATH } from "~/constants";
 
 export async function loader({ params, context }: DataFunctionArgs) {
   const blog = new D1BlogData(createD1Kysely(context.env.DB));
@@ -91,15 +92,15 @@ export const meta: MetaFunction = ({
   };
 };
 
-// Commenting out because I can't figure out how to not preload on subsequent client blog post navigations
-// export const links: LinksFunction = () => [
-//   {
-//     rel: "preload",
-//     href: `${SHIKI_PATH}/dist/onig.wasm`,
-//     as: "fetch",
-//     crossOrigin: "anonymous",
-//   },
-// ];
+// TODO: Figure out how to skip this preload on clientside navigations (if we've already seen a blog post)
+export const links: LinksFunction = () => [
+  {
+    rel: "preload",
+    href: `${SHIKI_PATH}/dist/onig.wasm`,
+    as: "fetch",
+    crossOrigin: "anonymous",
+  },
+];
 
 export default function BlogPost() {
   useClientNavigationLinks();

--- a/app/styles.css
+++ b/app/styles.css
@@ -80,4 +80,6 @@ nav.container.blog-nav {
 .post-content > article {
   background: none;
   padding: 0;
+  box-shadow: none;
+  border-radius: 0;
 }

--- a/app/styles.css
+++ b/app/styles.css
@@ -72,3 +72,12 @@ nav.container.blog-nav {
   margin-left: 0 auto;
   padding: var(--block-spacing-vertical) calc(var(--spacing));
 }
+
+/*
+ Markdoc renders an an "article" node at the top level of the post content.
+ This CSS overrides the default styling from pico of articles inside a post.
+ */
+.post-content > article {
+  background: none;
+  padding: 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@markdoc/markdoc": "^0.2.2",
         "@octokit/request": "^6.2.2",
         "@octokit/webhooks-methods": "^3.0.1",
         "@picocss/pico": "^1.5.6",
@@ -17,18 +18,17 @@
         "isbot": "^3.6.5",
         "kysely": "^0.23.4",
         "kysely-d1": "^0.2.0",
-        "marked": "^4.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "reading-time": "^1.5.0",
         "shiki": "0.11.1",
+        "suspense": "^0.0.10",
         "zod": "^3.19.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.18.0",
         "@remix-run/dev": "^1.11.0",
         "@remix-run/eslint-config": "^1.11.0",
-        "@types/marked": "^4.0.7",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "dotenv": "^16.0.3",
@@ -2545,6 +2545,29 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@markdoc/markdoc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.2.2.tgz",
+      "integrity": "sha512-0TiD9jmA5h5znN4lxo7HECAu3WieU5g5vUsfByeucrdR/x88hEilpt16EydFyJwJddQ/3w5HQgW7Ovy62r4cyw==",
+      "engines": {
+        "node": ">=14.7.0"
+      },
+      "optionalDependencies": {
+        "@types/markdown-it": "12.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@miniflare/cache": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.0.tgz",
@@ -3533,11 +3556,21 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/marked": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
-      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==",
-      "dev": true
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "optional": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -3552,7 +3585,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -3576,13 +3609,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.0.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3611,7 +3644,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -5235,7 +5268,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -9358,17 +9391,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -13629,6 +13651,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspense": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/suspense/-/suspense-0.0.10.tgz",
+      "integrity": "sha512-Ls16wZOqJFUukmYgGBVNcs0CP5v6BXhy7UIo5vJTsWRPAMUQG2b9SKkj05BVn+AY17YvaCAaeznXJ4QbgvNoxA==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.4.tgz",
@@ -16525,6 +16556,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@markdoc/markdoc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.2.2.tgz",
+      "integrity": "sha512-0TiD9jmA5h5znN4lxo7HECAu3WieU5g5vUsfByeucrdR/x88hEilpt16EydFyJwJddQ/3w5HQgW7Ovy62r4cyw==",
+      "requires": {
+        "@types/markdown-it": "12.2.3"
+      }
+    },
     "@miniflare/cache": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.0.tgz",
@@ -17290,11 +17329,21 @@
         "@types/node": "*"
       }
     },
-    "@types/marked": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
-      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==",
-      "dev": true
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "optional": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "optional": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -17309,7 +17358,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "dev": true
+      "devOptional": true
     },
     "@types/minimatch": {
       "version": "5.1.2",
@@ -17333,13 +17382,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "@types/react": {
       "version": "18.0.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -17368,7 +17417,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -18554,7 +18603,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "devOptional": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -21679,11 +21728,6 @@
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
       "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
       "dev": true
-    },
-    "marked": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw=="
     },
     "mdast-util-definitions": {
       "version": "5.1.1",
@@ -24815,6 +24859,12 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "suspense": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/suspense/-/suspense-0.0.10.tgz",
+      "integrity": "sha512-Ls16wZOqJFUukmYgGBVNcs0CP5v6BXhy7UIo5vJTsWRPAMUQG2b9SKkj05BVn+AY17YvaCAaeznXJ4QbgvNoxA==",
+      "requires": {}
     },
     "synckit": {
       "version": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@markdoc/markdoc": "^0.2.2",
     "@octokit/request": "^6.2.2",
     "@octokit/webhooks-methods": "^3.0.1",
     "@picocss/pico": "^1.5.6",
@@ -21,18 +22,17 @@
     "isbot": "^3.6.5",
     "kysely": "^0.23.4",
     "kysely-d1": "^0.2.0",
-    "marked": "^4.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reading-time": "^1.5.0",
     "shiki": "0.11.1",
+    "suspense": "^0.0.10",
     "zod": "^3.19.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.18.0",
     "@remix-run/dev": "^1.11.0",
     "@remix-run/eslint-config": "^1.11.0",
-    "@types/marked": "^4.0.7",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
- Renders markdown to an AST on the server
- Returns the AST from the loader to the client
- Map this AST to react components on the client

This is good because we don't need to ship markdown parsing code to the client anymore, or return a HTML string over the loader. This allows for interactive bits inside markdown.

---

Syntax highlighting now uses suspense. It uses a suspense cache to load the highlighter and relevant themes and languages for shiki.

It also means that client navigations don't flicker un-highlighted styles anymore, because we don't need to wait for an effect to run - we can just highlight the code if we have already loaded the relevant theme and language.

This is much nicer than the previous code that required a single shiki pass over all code nodes, this version feels more idiomatic to me.

It's not as ideal as doing the highlighting on the server. Still need to figure out how to run shiki on a cloudflare worker to unblock that.